### PR TITLE
Install missing package 'nodejs-npm'

### DIFF
--- a/Dockerfile.Gulp
+++ b/Dockerfile.Gulp
@@ -15,7 +15,7 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-RUN apk --no-cache add 'nodejs<7.0.0'
+RUN apk --no-cache add 'nodejs<7.0.0' nodejs-npm
 
 RUN npm install gulp-cli -g \
     && touch ~/.dummy \

--- a/Dockerfile.Node
+++ b/Dockerfile.Node
@@ -15,6 +15,6 @@ COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-RUN apk --no-cache add 'nodejs<7.0.0'
+RUN apk --no-cache add 'nodejs<7.0.0' nodejs-npm
 
 CMD ["surf"]


### PR DESCRIPTION
The package `t3easy/surf:node` does not contain the `npm` command anymore. The automatic build of `t3easy/surf:gulp` this mornig failed: https://hub.docker.com/r/t3easy/surf/builds/

The patch installes the additional package "nodejs-npm" and makes `npm` available again.