### PR TITLE
Create Dockerfile.Gulp-nodejs-v8.9

### DIFF
--- a/Dockerfile.Gulp-nodejs-v8.9
+++ b/Dockerfile.Gulp-nodejs-v8.9
@@ -1,0 +1,25 @@
+FROM composer
+
+RUN apk --no-cache add rsync
+
+ENV PATH "/tmp/vendor/bin:$PATH"
+ENV COMPOSER_HOME /tmp
+
+ENV SURF_VERSION 2.0.0-beta7
+
+RUN composer global config minimum-stability beta \
+    && composer global require typo3/surf:${SURF_VERSION} \
+    && composer clear-cache
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+RUN apk --no-cache add 'nodejs=8.9' nodejs-npm
+
+RUN npm install gulp-cli -g \
+    && touch ~/.dummy \
+    && npm cache clean \
+    && rm -f ~/.dummy
+
+CMD ["surf"]


### PR DESCRIPTION
Upgrade to current nodejs LTS 8.9, so the ZURB Foundation Template runs properly. 
https://github.com/zurb/foundation-zurb-template 